### PR TITLE
feat: Add a isGlobal option

### DIFF
--- a/src/oso.module.ts
+++ b/src/oso.module.ts
@@ -7,6 +7,7 @@ export interface OsoModuleConfig {
   loadStr?: string;
   loadFile?: string;
   osoOptions?: Options;
+  isGlobal?: boolean; // If true, registers `OsoModule` as a global module.
 }
 
 @Module({
@@ -18,6 +19,7 @@ export class OsoModule {
 
   static forRoot(options: OsoModuleConfig = {}): DynamicModule {
     return {
+      global: options.isGlobal,
       module: OsoModule,
       providers: [
         {


### PR DESCRIPTION
Closes #22 

Hi @cobraz , I've tried to import `OsoModule` as a global module, and I finally found this solution inspired by [@nestjs/config](https://github.com/nestjs/config/blob/e0aa56b35ffc67d1a5ae77ad4e15f5fced71eb8c/lib/config.module.ts#L102). 

Please take a look when you have time.