### PR TITLE
feat: update policy loading to reflect Oso 0.20.1 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,18 @@ import { OsoModule } from 'nestjs-oso';
 @Module({
   imports: [
     OsoModule.forRoot({
-      loadFile: './permissions.polar',
-      // or
-      // loadFile: './**/*.polar',
-      // loadFiles: ['./rules/*.polar', './permissions.polar'],
+      loadFiles: ['./permissions.polar'],
+      // or multiple files
+      // loadFiles: ['./permissions.polar', './other-policies.polar'],
+      // or using wildcards
+      // loadFiles: ['./**/*.polar']
     }),
   ],
 })
 export class AppModule {}
 ```
 
-**Tip:** You don't have to apply either `loadFile` or `loadStr`. You can inject
+**Tip:** You don't have to apply either `loadFiles` or `loadStr`. You can inject
 `OsoService` and access the original API for oso anytime!
 
 ### Example

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "husky": "7",
     "jest": "26.6.3",
     "lint-staged": "11.0.1",
-    "oso": "^0.14.0",
+    "oso": "^0.20.1",
     "prettier": "2.3.2",
     "ts-jest": "^26.4.4",
     "typescript": "4.1.4"
@@ -47,7 +47,7 @@
     "@nestjs/common": ">=7 <=8",
     "@nestjs/core": ">=7 <=8",
     "fast-glob": "^3",
-    "oso": ">=0.10.1"
+    "oso": ">=0.20.1"
   },
   "peerDependenciesMeta": {
     "fast-glob": {

--- a/src/__tests__/oso-service.test.ts
+++ b/src/__tests__/oso-service.test.ts
@@ -33,7 +33,7 @@ describe('OsoService', () => {
     expect(classes).toContain(TestClass);
   });
 
-  it('should load a file', async () => {
+  it('should load a file (deprecated)', async () => {
     const mod = await Test.createTestingModule({
       imports: [
         OsoModule.forRoot({
@@ -45,14 +45,33 @@ describe('OsoService', () => {
     const loadFileApp = mod.createNestApplication();
     const service = loadFileApp.get<OsoService>(OsoService);
     const func = jest
-      .spyOn(service, 'loadFile')
+      .spyOn(service, 'loadFiles')
       .mockImplementation(async () => {});
     await loadFileApp.init();
 
     expect(func).toBeCalledTimes(1);
   });
 
-  it('should load a files', async () => {
+  it('should load a file', async () => {
+    const mod = await Test.createTestingModule({
+      imports: [
+        OsoModule.forRoot({
+          loadFiles: [`${__dirname}/rule1.polar`],
+        }),
+      ],
+    }).compile();
+
+    const loadFileApp = mod.createNestApplication();
+    const service = loadFileApp.get<OsoService>(OsoService);
+    const func = jest
+      .spyOn(service, 'loadFiles')
+      .mockImplementation(async () => {});
+    await loadFileApp.init();
+
+    expect(func).toBeCalledTimes(1);
+  });
+
+  it('should load files', async () => {
     const mod = await Test.createTestingModule({
       imports: [
         OsoModule.forRoot({
@@ -64,14 +83,14 @@ describe('OsoService', () => {
     const loadFileApp = mod.createNestApplication();
     const service = loadFileApp.get<OsoService>(OsoService);
     const func = jest
-      .spyOn(service, 'loadFile')
+      .spyOn(service, 'loadFiles')
       .mockImplementation(async () => {});
     await loadFileApp.init();
 
-    expect(func).toBeCalledTimes(2);
+    expect(func).toBeCalledTimes(1);
   });
 
-  it('should load files using regex', async () => {
+  it('should load a file using regex (deprecated)', async () => {
     const mod = await Test.createTestingModule({
       imports: [
         OsoModule.forRoot({
@@ -83,11 +102,30 @@ describe('OsoService', () => {
     const loadFileApp = mod.createNestApplication();
     const service = loadFileApp.get<OsoService>(OsoService);
     const func = jest
-      .spyOn(service, 'loadFile')
+      .spyOn(service, 'loadFiles')
       .mockImplementation(async () => {});
     await loadFileApp.init();
 
-    expect(func).toBeCalledTimes(2);
+    expect(func).toBeCalledTimes(1);
+  });
+
+  it('should load files using regex', async () => {
+    const mod = await Test.createTestingModule({
+      imports: [
+        OsoModule.forRoot({
+          loadFiles: ['./**/*.polar'],
+        }),
+      ],
+    }).compile();
+
+    const loadFileApp = mod.createNestApplication();
+    const service = loadFileApp.get<OsoService>(OsoService);
+    const func = jest
+      .spyOn(service, 'loadFiles')
+      .mockImplementation(async () => {});
+    await loadFileApp.init();
+
+    expect(func).toBeCalledTimes(1);
   });
 
   it('should load strings', async () => {

--- a/src/oso.module.ts
+++ b/src/oso.module.ts
@@ -5,7 +5,10 @@ import { OsoService } from './oso.service';
 
 export interface OsoModuleConfig {
   loadStr?: string;
-  loadFile?: string; // Deprecated; to be removed in next major version
+  /**
+  * @deprecated This argument will be removed in next major version
+  */
+  loadFile?: string;
   loadFiles?: string[];
   osoOptions?: Options;
   isGlobal?: boolean; // If true, registers `OsoModule` as a global module.

--- a/src/oso.module.ts
+++ b/src/oso.module.ts
@@ -5,7 +5,7 @@ import { OsoService } from './oso.service';
 
 export interface OsoModuleConfig {
   loadStr?: string;
-  loadFile?: string;
+  loadFile?: string; // Deprecated; to be removed in next major version
   loadFiles?: string[];
   osoOptions?: Options;
   isGlobal?: boolean; // If true, registers `OsoModule` as a global module.

--- a/src/oso.service.ts
+++ b/src/oso.service.ts
@@ -20,11 +20,11 @@ export class OsoService extends Oso implements OnModuleInit {
     });
 
     if (this.options.loadFile) {
-      await this.loadFiles([this.options.loadFile]);
+      await this._loadFiles([this.options.loadFile]);
     }
 
     if (this.options.loadFiles) {
-      await this.loadFiles(this.options.loadFiles);
+      await this._loadFiles(this.options.loadFiles);
     }
 
     if (this.options.loadStr) {
@@ -32,12 +32,8 @@ export class OsoService extends Oso implements OnModuleInit {
     }
   }
 
-  private async loadFiles(patterns: string[]): Promise<void> {
+  private async _loadFiles(patterns: string[]): Promise<void> {
     const files = await FastGlob(patterns);
-    await Promise.all(
-      files.map(async (file: string) => {
-        await this.loadFile(file);
-      }),
-    );
+    await this.loadFiles(files);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3963,10 +3963,10 @@ optionator@^0.9.1:
     type-check "^0.4.0"
     word-wrap "^1.2.3"
 
-oso@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/oso/-/oso-0.14.0.tgz#6a033717193ee55be5936b049b685db6ebe3da5c"
-  integrity sha512-DWFm+vYYHepigiK2zMb9sP5lg/L1J9ShNQygtdUnUbBKacojYaXArjGlf2zyXvFJcy2FZX3q5iOGPREt+z7r2Q==
+oso@^0.20.1:
+  version "0.20.1"
+  resolved "https://registry.yarnpkg.com/oso/-/oso-0.20.1.tgz#f41762198dcfb99a99c42660d23cb5eb7eef239f"
+  integrity sha512-LLXU+GlnX95nGGU21RX/vwAVIdZeZ73nlfHvkMcFpUeLMGARDSI8anKgZpOQ8JGMehQP10X3pdXFWnG1udMeCQ==
 
 p-each-series@^2.1.0:
   version "2.2.0"


### PR DESCRIPTION
An attempt to resolve #258.

A few comments, mostly due to my lack of experience:
- As discussed, left the `loadFile` option in for backwards compatibility, however do not have any experience with typedoc so the proposed reference is not provided
- Updated dependencies and peerDependencies to `oso@0.20.1` or higher
- Updated tests to include various cases of both deprecated `loadFile` and `loadFiles` options
- Kept `fast-glob` dependency, because was unsure how path wildcards can be used in Oso

Please suggest changes/improvements or directly implement edits. Thank you!